### PR TITLE
Fix transitive import change does not cause refresh

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -22,15 +22,39 @@ const render = async (filepath, options) => {
 };
 
 module.exports = function plugin(snowpackConfig, options = {}) {
+  /** A map of imported paths to the files that imported them. */
+  const importedByMap = new Map();
+
+  function addImportsToMap(filePath, importedPath) {
+    const importedBy = importedByMap.get(importedPath);
+    if (importedBy) {
+      importedBy.add(filePath);
+    } else {
+      importedByMap.set(importedPath, new Set([filePath]));
+    }
+  }
+
   return {
     name: pkg.name,
     resolve: {
       input: ['.less'],
       output: ['.css'],
     },
-    async load({ filePath }) {
+    onChange({ filePath }) {
+      if (importedByMap.has(filePath)) {
+        const importedBy = importedByMap.get(filePath);
+        importedByMap.delete(filePath);
+        for (const importerFilePath of importedBy) {
+          this.markChanged(importerFilePath);
+        }
+      }
+    },
+    async load({ filePath, isDev }) {
       try {
         const result = await render(filePath, options);
+        if (isDev) {
+          result.imports.forEach(importedPath => addImportsToMap(filePath, importedPath));
+        }
         return {
           '.css': result.css,
         };


### PR DESCRIPTION
Hi there,

Thanks for creating this plugin!
Currently when a less file B is imported from other less file A any changes to file B will not cause Snowpack to refresh the css file which was generated from A.

This PR fixes this by remembering the imports processed when compiling file A and marking A is changed when B has been modified. The implementation is inspired by the [Snowpack SASS plugin](https://github.com/snowpackjs/snowpack/blob/1233a51b82bb92022392a3e76c73c9bcc3bbfd4b/plugins/plugin-sass/plugin.js#L12).

Cheers,
Florian